### PR TITLE
Add Jacoco to generate code coverage report + exclude lombok code from it.

### DIFF
--- a/DeliveryApi/ApiHandlers/build.gradle
+++ b/DeliveryApi/ApiHandlers/build.gradle
@@ -11,6 +11,7 @@ plugins {
     id 'java-library'
     id "nebula.lint" version "16.9.0"
     id 'checkstyle'
+    id 'jacoco'
 }
 
 checkstyle {
@@ -23,6 +24,10 @@ checkstyle {
     configFile = file('config/checkstyle/checkstyle.xml')
     // Allow some warnings before putting checkstyle in place. These warning will be gradually removed.
     maxWarnings = 26
+}
+
+jacoco {
+    toolVersion = "0.8.7"
 }
 
 //gradleLint {
@@ -73,6 +78,14 @@ test {
     useJUnitPlatform()
     // Use this flag to show output from running the test
     // testLogging.showStandardStreams = true
+
+    // report is always generated after tests run
+    finalizedBy jacocoTestReport
+
+}
+
+jacocoTestReport {
+    dependsOn test // tests are required to run before generating the report
 }
 
 sourceSets {

--- a/DeliveryApi/ApiHandlers/lombok.config
+++ b/DeliveryApi/ApiHandlers/lombok.config
@@ -1,0 +1,2 @@
+config.stopBubbling = true
+lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Add Jacoco in Gradle build to generate code coverage report 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.