### PR TITLE
changes to dbinit.sql will trigger executing sql script in Populate Lambda

### DIFF
--- a/DeliveryApi/ApiHandlers/build.gradle
+++ b/DeliveryApi/ApiHandlers/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
 
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
-    implementation 'com.amazonaws:aws-lambda-java-events:2.2.9'
+    implementation 'com.amazonaws:aws-lambda-java-events:3.9.0'
     runtimeOnly 'mysql:mysql-connector-java:8.0.15'
     implementation 'org.json:json:20210307'
 

--- a/DeliveryApi/cdk/src/main/java/com/ilmlf/delivery/api/ApiStack.java
+++ b/DeliveryApi/cdk/src/main/java/com/ilmlf/delivery/api/ApiStack.java
@@ -154,7 +154,7 @@ public class ApiStack extends Stack {
     // we will pass in the contents of the SQL File, so that any changes in the file
     // trigger an 'Update' and executes the Populator lambda (which executes the sql statement)
     String scriptFile = "../ApiHandlers/scripts/com/ilmlf/db/dbinit.sql";
-    String sqlScript = new String (Files.readAllBytes( Paths.get(scriptFile)));
+    String sqlScript = new String(Files.readAllBytes(Paths.get(scriptFile)));
     
     new CustomResource(
         this,

--- a/DeliveryApi/cdk/src/main/java/com/ilmlf/delivery/api/ApiStack.java
+++ b/DeliveryApi/cdk/src/main/java/com/ilmlf/delivery/api/ApiStack.java
@@ -25,6 +25,8 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -125,11 +127,11 @@ public class ApiStack extends Stack {
   }
 
   /**
-   * Creates a custom resource to populate tables in the database when it's first deployed.
+   * Create a custom resource to populate tables in the database when it's first deployed.
    *
-   * A Custom Resource is CloudFormation's feature to execute user provided code to create/update/delete resources.
-   * For a resource that isn't available in CloudFormation, we can write custom code to manage its life cycle and let
-   * the custom resource run the code when the stack is created, updated or deleted.
+   * A Custom resource is a CloudFormation feature for execute=ing user provided code to create/update/delete resources.
+   * For resources that aren't available in CloudFormation, we can write custom code to manage their life cycle and let
+   * custom resource manage the resource when the stack is created, updated or deleted.
    *
    * In this case, the custom resource will run the Lambda function handler ("PopulateFarmDb") which contains
    * code to initialize the tables.
@@ -137,7 +139,7 @@ public class ApiStack extends Stack {
    * See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-custom-resources.html for details about custom resource
    */
   private void createCustomResourceToPopulateDb(ApiStackProps props, Role lambdaRdsProxyRoleWithPw) throws IOException {
-    // See https://docs.aws.amazon.com/cdk/api/latest/docs/custom-resources-readme.html for details on writing a Lambda function
+    // See https://docs.aws.amazon.com/cdk/api/latest/java/software/amazon/awscdk/customresources/package-summary.html for details on writing a Lambda function
     // and providers
     Function dbPopulatorHandler =
         DefaultLambdaRdsProxy("PopulateFarmDb", props, lambdaRdsProxyRoleWithPw);
@@ -149,12 +151,18 @@ public class ApiStack extends Stack {
             "InvokePopulateDataProvider",
             ProviderProps.builder().onEventHandler(dbPopulatorHandler).build());
 
+    // we will pass in the contents of the SQL File, so that any changes in the file
+    // trigger an 'Update' and executes the Populator lambda (which executes the sql statement)
+    String scriptFile = "../ApiHandlers/scripts/com/ilmlf/db/dbinit.sql";
+    String sqlScript = new String ( Files.readAllBytes( Paths.get(scriptFile)));
+    
     new CustomResource(
         this,
-        "PopulateDataProviderv21",
+        "PopulateDataProviderv22",
         CustomResourceProps.builder()
             .serviceToken(dbPopulatorProvider.getServiceToken())
             .resourceType("Custom::PopulateDataProvider")
+            .properties(Map.of("SqlScript",sqlScript))
             .build());
   }
 

--- a/DeliveryApi/cdk/src/main/java/com/ilmlf/delivery/api/ApiStack.java
+++ b/DeliveryApi/cdk/src/main/java/com/ilmlf/delivery/api/ApiStack.java
@@ -154,7 +154,7 @@ public class ApiStack extends Stack {
     // we will pass in the contents of the SQL File, so that any changes in the file
     // trigger an 'Update' and executes the Populator lambda (which executes the sql statement)
     String scriptFile = "../ApiHandlers/scripts/com/ilmlf/db/dbinit.sql";
-    String sqlScript = new String ( Files.readAllBytes( Paths.get(scriptFile)));
+    String sqlScript = new String (Files.readAllBytes( Paths.get(scriptFile)));
     
     new CustomResource(
         this,

--- a/DeliveryApi/cdk/src/main/java/com/ilmlf/delivery/api/ApiStack.java
+++ b/DeliveryApi/cdk/src/main/java/com/ilmlf/delivery/api/ApiStack.java
@@ -129,7 +129,7 @@ public class ApiStack extends Stack {
   /**
    * Create a custom resource to populate tables in the database when it's first deployed.
    *
-   * A Custom resource is a CloudFormation feature for execute=ing user provided code to create/update/delete resources.
+   * A Custom resource is a CloudFormation feature for executing user provided code to create/update/delete resources.
    * For resources that aren't available in CloudFormation, we can write custom code to manage their life cycle and let
    * custom resource manage the resource when the stack is created, updated or deleted.
    *


### PR DESCRIPTION
Description of changes:
The ApiStack keeps track of dbinit.sql changes and triggers an update when it does. 
The Populator Lambda executes the dbinit.sql when the requestType is Update or Create, in order to avoid executing twice on resource replacements (which issue a Create + Delete request). The Lambda also returns the Physical Resource Id and a boolean on whether the script ran or not.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.