### PR TITLE
remove unnecessary kmsDecrypt policy

### DIFF
--- a/DeliveryApi/cdk/src/main/java/com/ilmlf/delivery/api/ApiStack.java
+++ b/DeliveryApi/cdk/src/main/java/com/ilmlf/delivery/api/ApiStack.java
@@ -202,22 +202,6 @@ public class ApiStack extends Stack {
                 .resources(List.of(dbAdminSecretArn, dbUserSecretArn))
                 .build()));
 
-
-    // Allow Lambda to decrypt secret used to connect to the RDS database
-    lambdaRdsRoleWithPw.addToPolicy(
-        new PolicyStatement(
-            PolicyStatementProps.builder()
-                .effect(Effect.ALLOW)
-                .actions(List.of("kms:Decrypt")) // needed for lambda to connect to RDS Proxy
-                .resources(
-                    List.of(
-                        "arn:aws:kms:"
-                            + Stack.of(this).getRegion()
-                            + ":"
-                            + Stack.of(this).getAccount()
-                            + ":key/*"))
-                .build()));
-
     return lambdaRdsRoleWithPw;
   }
 


### PR DESCRIPTION
Description of changes: Removed unnecessary kms:decrypt policy from Populator lambda, since SecretsManager's aws/secretsmanager KMS policy already has rights to decrypt.

Tested on the console invoking the Populator lambda, as well as through the custom resource (by touching the dbinit.sql file). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.