### PR TITLE
Add ECS service to DB vpc, create stack dependency

### DIFF
--- a/JavaSpringMigration/README.md
+++ b/JavaSpringMigration/README.md
@@ -65,7 +65,7 @@ The code contains two folders:
    Powershell on Windows
     ```
     cd cdk
-    rm -r ../app/target # Remove previous build
+    rm -r ../app/target # Remove previous app build
     rm -r cdk.out # Remove previous build
     npx cdk deploy --all --profile <PROFILE_NAME> 
     ```

--- a/JavaSpringMigration/cdk/README.md
+++ b/JavaSpringMigration/cdk/README.md
@@ -1,5 +1,7 @@
 # ECS and ECR Infrastructure for Provman App
 
+This directory contains  CDK code for deploying the Provman application into the cloud.
+
 ## Deployment
 
 This CDK code can be deployed in just a few steps,

--- a/JavaSpringMigration/cdk/src/main/java/com/ilmlf/product/ProvmanApp.java
+++ b/JavaSpringMigration/cdk/src/main/java/com/ilmlf/product/ProvmanApp.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
 import software.amazon.awscdk.core.Annotations;
 import software.amazon.awscdk.core.App;
 import software.amazon.awscdk.core.Construct;

--- a/JavaSpringMigration/cdk/src/main/java/com/ilmlf/product/api/ApiStack.java
+++ b/JavaSpringMigration/cdk/src/main/java/com/ilmlf/product/api/ApiStack.java
@@ -18,7 +18,6 @@ import java.util.Map;
 import lombok.Data;
 import software.amazon.awscdk.core.Annotations;
 import software.amazon.awscdk.core.Construct;
-import software.amazon.awscdk.core.Fn;
 import software.amazon.awscdk.core.Stack;
 import software.amazon.awscdk.core.StackProps;
 import software.amazon.awscdk.services.ec2.Vpc;
@@ -55,7 +54,7 @@ public class ApiStack extends Stack {
         .clusterName("ProvmanCluster")
         .build());
 
-    ISecret dbPasswordSecret = Secret.fromSecretCompleteArn(this, "DbPasswordSecret", Fn.importValue(props.jdbcSecretArn));
+    ISecret dbPasswordSecret = Secret.fromSecretCompleteArn(this, "DbPasswordSecret", props.jdbcSecretArn);
 
     ApplicationLoadBalancedFargateService fargateService = new ApplicationLoadBalancedFargateService(this, "FargateService",
         ApplicationLoadBalancedFargateServiceProps.builder()
@@ -68,7 +67,7 @@ public class ApiStack extends Stack {
                     software.amazon.awscdk.services.ecs.Secret.fromSecretsManager(dbPasswordSecret)))
                 .environment(Map.of(
                     "DB_USERNAME", props.jdbcUsername,
-                    "ENDPOINT_URL", "jdbc:mysql://" + Fn.importValue(props.jdbcEndpointUrl) + "/" + props.dbName
+                    "ENDPOINT_URL", "jdbc:mysql://" + props.jdbcEndpointUrl + "/" + props.dbName
                 ))
                 .build())
             .desiredCount(1)

--- a/JavaSpringMigration/cdk/src/main/java/com/ilmlf/product/cicd/ProvmanStage.java
+++ b/JavaSpringMigration/cdk/src/main/java/com/ilmlf/product/cicd/ProvmanStage.java
@@ -35,27 +35,25 @@ import java.io.IOException;
  * </p>
  */
 public class ProvmanStage extends Stage {
-    private static final String DB_SECRET_EXPORT_NAME = "DbSecret";
-    private static final String DB_ENDPOINT_URL_EXPORT_NAME = "DbEndpointUrl";
 
-    public ProvmanStage(Construct scope,
-                        java.lang.String id,
-                        StageProps props) throws Exception {
+    public ProvmanStage(Construct scope, java.lang.String id, StageProps props) throws Exception {
         super(scope, id, props);
-        DbStack dbStack = new DbStack(this, "ProvmanDbStack",DbStack.DbStackProps.builder()
+
+        DbStack dbStack = new DbStack(this, "ProvmanDbStack", DbStack.DbStackProps.builder()
             .dbPort(3306)
             .dbName("ProvmanDb")
             .dbUsername("admin")
-            .dbSecretExportName(DB_SECRET_EXPORT_NAME)
-            .dbEndpointUrlExportName(DB_ENDPOINT_URL_EXPORT_NAME)
             .build());
 
         ApiStack apiStack = new ApiStack(this, "ProvmanClusterStack", ApiStack.ApiStackProps.builder()
             .jdbcUsername(dbStack.getDbUsername())
-            .jdbcSecretArn(DB_SECRET_EXPORT_NAME)
-            .jdbcEndpointUrl(DB_ENDPOINT_URL_EXPORT_NAME)
+            .jdbcSecretArn(dbStack.getAdminSecret().getSecretFullArn())
+            .jdbcEndpointUrl(dbStack.getInstanceEndpoint())
             .dbName(dbStack.getDbName())
+            .vpc(dbStack.getVpc())
             .build());
+
+        apiStack.addDependency(dbStack);
 
     }
 

--- a/JavaSpringMigration/cdk/src/main/java/com/ilmlf/product/db/DbStack.java
+++ b/JavaSpringMigration/cdk/src/main/java/com/ilmlf/product/db/DbStack.java
@@ -81,8 +81,6 @@ public class DbStack extends Stack {
     private Integer dbPort;
     private Environment env;
     private boolean isPublicSubnetDb;
-    private String dbSecretExportName;
-    private String dbEndpointUrlExportName;
     private String dbName;
   }
 
@@ -184,15 +182,5 @@ public class DbStack extends Stack {
 
     this.instanceEndpoint = farmerDb.getDbInstanceEndpointAddress() + ":" + farmerDb.getDbInstanceEndpointPort();
     this.adminSecret = farmerDb.getSecret();
-
-    new CfnOutput(this, "DbEndpointUrl", CfnOutputProps.builder()
-        .value(this.instanceEndpoint)
-        .exportName(props.dbEndpointUrlExportName)
-        .build());
-
-    new CfnOutput(this, "DbSecret", CfnOutputProps.builder()
-        .value(this.adminSecret.getSecretFullArn())
-        .exportName(props.dbSecretExportName)
-        .build());
   }
 }


### PR DESCRIPTION
During code copy, the API stack was no longer correctly placed in the DB vpc, causing a connection issue.