### PR TITLE
fix: log4j 2.17 to avoid CVE 2021 45046 in DeliveryApi

### DIFF
--- a/DeliveryApi/ApiHandlers/build.gradle
+++ b/DeliveryApi/ApiHandlers/build.gradle
@@ -67,22 +67,23 @@ dependencies {
 
     // Log4j2 logging framework dependencies
     implementation group: 'com.amazonaws', name: 'aws-lambda-java-log4j2', version: '1.3.0'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.16.0'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.16.0'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.17.0'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.0'
 
     // compileOnly means that this will not have an impact on cold start times, as it's not part of the final artifact
     compileOnly "org.projectlombok:lombok:1.18.20"
     annotationProcessor 'org.projectlombok:lombok:1.18.20'
 
-    // Prevent using feature log4j below 2.16.0 which can contain CVE-2021-44228
+    // Prevent using feature log4j below 2.17.0 which can contain CVE-2021-44228 and CVE-2021-45046
     // See step 3 in https://blog.gradle.org/log4j-vulnerability 
     constraints {
         implementation("org.apache.logging.log4j:log4j-core") {
             version {
-                strictly("[2.16, 3[")
-                prefer("2.16.0")
+                strictly("[2.17, 3[")
+                prefer("2.17.0")
             }
             because("CVE-2021-44228: Log4j vulnerable to remote code execution")
+            because("CVE-2021-45046: Log4j vulnerable to DoS attack")
         }
     }
 }

--- a/FlywayLambdaService/build.gradle
+++ b/FlywayLambdaService/build.gradle
@@ -48,8 +48,8 @@ dependencies {
     implementation group: 'org.json', name: 'json', version: '20190722'
     implementation group: 'org.postgresql', name: 'postgresql', version: '42.2.5'
     implementation group: 'mysql', name: 'mysql-connector-java', version: '8.0.16'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.16.0'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.16.0'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.0'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.17.0'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
     implementation group: 'com.amazonaws', name: 'aws-lambda-java-core', version: '1.2.0'
     implementation group: 'com.amazonaws', name: 'aws-lambda-java-log4j2', version: '1.4.0'
@@ -68,15 +68,16 @@ dependencies {
     testCompile group: 'org.testcontainers', name: 'postgresql', version: '1.16.2'
     testCompile group: 'org.testcontainers', name: 'mysql', version: '1.16.2'
 
-    // Prevent using feature log4j below 2.16.0 which can contain CVE-2021-44228
+    // Prevent using feature log4j below 2.17.0 which can contain CVE-2021-44228 and CVE-2021-45046
     // See step 3 in https://blog.gradle.org/log4j-vulnerability
     constraints {
         implementation("org.apache.logging.log4j:log4j-core") {
             version {
-                strictly("[2.16, 3[")
-                prefer("2.16.0")
+                strictly("[2.17, 3[")
+                prefer("2.17.0")
             }
             because("CVE-2021-44228: Log4j vulnerable to remote code execution")
+            because("CVE-2021-45046: Log4j vulnerable to DoS attack")
         }
     }
 }


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- bump log4j 2.17 to avoid CVE-2021-45046

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.